### PR TITLE
DEV-12525 fix: dinamic client to get mainnet or testnet

### DIFF
--- a/src/context/UpProvider.tsx
+++ b/src/context/UpProvider.tsx
@@ -25,6 +25,7 @@ import {
   useEffect,
   useState,
   ReactNode,
+  useMemo,
 } from "react";
 
 interface UpProviderContext {
@@ -55,7 +56,6 @@ interface UpProviderProps {
 }
 
 export function UpProvider({ children }: UpProviderProps) {
-  const [client, setClient] = useState<WalletClient | null>(null);
   const [provider] = useState(() =>
     typeof window !== "undefined" ? createClientUPProvider() : null
   );
@@ -71,16 +71,15 @@ export function UpProvider({ children }: UpProviderProps) {
   );
   const [isSearching, setIsSearching] = useState(false);
 
-  useEffect(() => {
-    if (provider) {
-      const newClient = createWalletClient({
+  const client: WalletClient | null = useMemo(() => {
+    if (provider && chainId) {
+      return createWalletClient({
         chain: chainId === 42 ? lukso : luksoTestnet,
         transport: custom(provider),
       });
-
-      setClient(newClient);
     }
-  }, [chainId]);
+    return null;
+  }, [provider, chainId]);
 
   useEffect(() => {
     let mounted = true;

--- a/src/context/UpProvider.tsx
+++ b/src/context/UpProvider.tsx
@@ -136,7 +136,7 @@ export function UpProvider({ children }: UpProviderProps) {
         provider.removeListener("chainChanged", chainChanged);
       };
     }
-  }, [provider, accounts.length, contextAccounts.length]);
+  }, [client, provider, accounts.length, contextAccounts.length]);
 
   return (
     <UpContext.Provider

--- a/src/hooks/useSmartContract.tsx
+++ b/src/hooks/useSmartContract.tsx
@@ -4,7 +4,7 @@ import lsp7Json from "../json/lsp7/lsp7.json";
 import { useUpProvider } from "../context/UpProvider";
 
 export const useSmartContract = () => {
-  const { client, walletConnected, accounts } = useUpProvider();
+  const { client, walletConnected, accounts, chainId } = useUpProvider();
 
   {
     /**
@@ -48,8 +48,13 @@ export const useSmartContract = () => {
       if (!client) {
         return;
       }
+      const contractAddressMainnet: `0x${string}` =
+        "0xA8Cb54517380B2df303BD00e8a512d478651ac4C";
+      const contractAddressTestnet: `0x${string}` =
+        "0x4E1Fe6B4085D79F5F500B835f3a2a56F27994338";
+
       const contractAddress: `0x${string}` =
-        "0x4E1Fe6B4085D79F5F500B835f3a2a56F27994338"; // Example of a custom smart contract LSP7 address already deployed
+        chainId === 42 ? contractAddressMainnet : contractAddressTestnet; // Example of a custom smart contract LSP7 address already deployed
 
       const contract = await getContractInstance(contractAddress, client);
       const data: string = contract.interface.encodeFunctionData("allCanMint"); // this is a custom function
@@ -60,7 +65,6 @@ export const useSmartContract = () => {
         data: data,
       });
       return txResponse;
-      
     } catch (error) {
       console.error("Transaction failed:", error);
       return;
@@ -112,7 +116,7 @@ export const useSmartContract = () => {
         return tx;
       } catch (error) {
         console.error("Transaction failed:", error);
-        return
+        return;
       }
     },
     [getSigner, getContractInstance]

--- a/src/hooks/useSmartContract.tsx
+++ b/src/hooks/useSmartContract.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { BrowserProvider, Contract, ethers, JsonRpcSigner } from "ethers";
 import lsp7Json from "../json/lsp7/lsp7.json";
 import { useUpProvider } from "../context/UpProvider";
+import { lukso } from "viem/chains";
 
 export const useSmartContract = () => {
   const { client, walletConnected, accounts, chainId } = useUpProvider();
@@ -54,7 +55,7 @@ export const useSmartContract = () => {
         "0x4E1Fe6B4085D79F5F500B835f3a2a56F27994338";
 
       const contractAddress: `0x${string}` =
-        chainId === 42 ? contractAddressMainnet : contractAddressTestnet; // Example of a custom smart contract LSP7 address already deployed
+        chainId === lukso.id ? contractAddressMainnet : contractAddressTestnet; // Example of a custom smart contract LSP7 address already deployed
 
       const contract = await getContractInstance(contractAddress, client);
       const data: string = contract.interface.encodeFunctionData("allCanMint"); // this is a custom function


### PR DESCRIPTION
The previous UP provider had to be statically configured to operate on mainnet or testnet. Now, it is set up automatically based on the chainId.

This way, I can also set up two different smart contracts to interact with, one for the mainnet and one for the testnet.

benefits: easy to set up for users